### PR TITLE
chore: use css.parser.tailwindDirectives instead of noUnknownAtRules ignore

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,18 +11,15 @@
     "indentWidth": 2,
     "lineWidth": 120
   },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
+  },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
-      "suspicious": {
-        "noUnknownAtRules": {
-          "level": "error",
-          "options": {
-            "ignore": ["tailwind"]
-          }
-        }
-      }
+      "recommended": true
     }
   },
   "assist": {


### PR DESCRIPTION
## Summary

- Replace the `noUnknownAtRules` lint override (which only suppressed `@tailwind`) with Biome's `css.parser.tailwindDirectives: true` option
- This is a parser-level setting that natively understands all Tailwind at-rules: `@apply`, `@theme`, `@utility`, `@variant`, etc.
- The old workaround was also targeting `@tailwind` — a directive Tailwind v4 no longer uses

## Test plan

- [ ] `npm run biome:check` passes