### PR TITLE
ci: add Trivy security scan workflow

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,35 @@
+name: Security Scan (Trivy)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  fs-scan:
+    name: Filesystem & IaC Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run Trivy vulnerability scanner (FS)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-fs-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-fs-results.sarif'
+          category: 'filesystem-scan'


### PR DESCRIPTION
## Summary

- Adds a Trivy security scan workflow that runs on push to \`main\`, pull requests targeting \`main\`, and on a weekly schedule (Mondays 00:00 UTC)
- Filesystem scan posts results to GitHub Security tab under category \`filesystem-scan\`
- Only \`CRITICAL\` and \`HIGH\` severity findings reported; unfixed vulnerabilities excluded