### PR TITLE
ci: add minimum workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds top-level `permissions: contents: read` to satisfy the `actions/missing-workflow-permissions` code scanning rule.

No functional change — the workflows previously relied on the repo's default token permissions. The release workflow uses a custom PAT (`RELEASE_PLEASE_TOKEN`) rather than `GITHUB_TOKEN` for its write operations, so this change doesn't affect it.